### PR TITLE
Use m.group(1) regex syntax

### DIFF
--- a/mychevy/mychevy.py
+++ b/mychevy/mychevy.py
@@ -258,7 +258,7 @@ class MyChevy(object):
         if not m:
             raise ValueError("SETTINGS not found in response")
 
-        settings_json = json.loads(m[1])
+        settings_json = json.loads(m.group(1))
         csrf = settings_json["csrf"]
         trans_id = settings_json["transId"]
 


### PR DESCRIPTION
For compatibility with python3.5, Use m.group(1) regex syntax since m[1] support is new in python 3.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdague/mychevy/17)
<!-- Reviewable:end -->
